### PR TITLE
Introduce gover.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-    - 1.11
+    - 1.14
 jobs:
   include:
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ jobs:
       stage: 'unit test'
       install:
         - go get golang.org/x/tools/cmd/cover
+        - go get github.com/modocache/gover
         - go get github.com/mattn/goveralls
       before_script:
         - 'curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh'
       script:
         - 'make test'
-        - '$HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN'
+        - 'gover'
+        - '$HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN'

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/freerware/work v2.0.1+incompatible
 	github.com/freerware/workfx v2.0.1+incompatible // indirect
+	github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/uber-go/tally v3.3.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5 h1:8Q0qkMVC/MmWkpIdlvZgcv2o2jrlF6zqVOh7W5YHdMA=
+github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
**Description**

Modifies `.travis.yml` to utilize `gover` to adequately report code coverage for all packages.

**Rationale**

With the introduction of `v4.0.0-beta`, test code has been placed in `workfx_test`. additionally, coverage profiles for `v4` were not being captured because separate `coverage.out` files were generated per package.

**Suggested Version**

`v4.0.0-beta`

**Example Usage**

N/A
